### PR TITLE
Update agenda schema and version

### DIFF
--- a/meta/schemas/agenda-1.0.json
+++ b/meta/schemas/agenda-1.0.json
@@ -1,0 +1,41 @@
+{
+    "version": "1.0",
+    "data": {
+        "date": "August 7, 2018",
+        "officers": {
+            "president": "KC Lakshminarasimham",
+            "vpm": "Anny He",
+            "vpe": "Srinath Krishna Ananthakrishnan",
+            "vppr": "Max Kukartsev",
+            "secretary": "Rosaura Arevalo",
+            "soa": "Jack Faraday",
+            "treasurer": "Ron Sison"
+        },
+        "items": {
+            "jokemaster": "[a quasi-funny person]",
+            "toastmaster": "Max Kukartsev",
+            "grammarian": "Rosaura Arevalo",
+            "ah counter": "Jack Faraday",
+            "timer": "Jack Faraday",
+            "topicsmaster": "Anny He",
+            "speeches": [
+                {
+                    "project": "(Just having a project without a track is supported)",
+                    "title": "Blah blah blah",
+                    "speaker": "KC Lakshminarasimham",
+                    "duration": "5-15 minutes"
+                },
+                {
+                    "track": "Pathways - Dynamic Leadership",
+                    "project": "(L1) Evaluation and Feedback #1 (5-7 min)",
+                    "title": "Bleh Bleh Bleh",
+                    "speaker": "Srinath Krishna Ananthakrishnan",
+                    "duration": "5-7 minutes"
+                }
+            ],
+            "general evaluator": "Ron Sison",
+            "evaluator 1": "Anny He",
+            "evaluator 2": "Max Kukartsev"
+        }
+    }
+}

--- a/meta/schemas/agenda-1.1.json
+++ b/meta/schemas/agenda-1.1.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0",
+    "version": "1.1",
     "data": {
         "date": "August 7, 2018",
         "officers": {

--- a/meta/schemas/agenda-1.2.json
+++ b/meta/schemas/agenda-1.2.json
@@ -1,0 +1,42 @@
+{
+    "version": "1.2",
+    "data": {
+        "date": "August 7, 2018",
+        "officers": {
+            "president": "KC Lakshminarasimham",
+            "vpm": "Anny He",
+            "vpe": "Srinath Krishna Ananthakrishnan",
+            "vppr": "Max Kukartsev",
+            "secretary": "Rosaura Arevalo",
+            "soa": "Jack Faraday",
+            "treasurer": "Ron Sison"
+        },
+        "items": {
+            "jokemaster": "Tony Stark",
+            "toastmaster": "Max Kukartsev",
+            "grammarian": "Rosaura Arevalo",
+            "ah counter": "Jack Faraday",
+            "timer": "Nicholas Cage",
+            "topicsmaster": "Anny He",
+            "speeches": [
+                {
+                    "track": "Pathways - Dynamic Leadership",
+                    "project": "(L1) Evaluation and Feedback #2 (5-7 min)",
+                    "duration": 7,
+                    "speaker": "Anny He",
+                    "title": "hello",
+                    "evaluator": "Amar She"
+                },
+                {
+                    "track": "Pathways - Dynamic Leadership",
+                    "project": "(L1) Ice Breaker (4-6 min)",
+                    "duration": 6,
+                    "speaker": "Srinath Krishna Ananthakrishnan",
+                    "title": "Why pizza boxes are square, pizzas circular, and pizza slices triangular",
+                    "evaluator": "Max Kukartsev"
+                }
+            ],
+            "general evaluator": "Ron Sison"
+        }
+    }
+}


### PR DESCRIPTION
> **Note:** Agenda version "1.0" is the version presently supported by [https://toastmasters-dev.github.io/print-agenda/?data={"version":"1.0", ...}](https://toastmasters-dev.github.io/print-agenda/?data={"version":"1.0", ...}). Since the site was deployed, version "1.0" was changed here. However, since this does not reflect the state of the printing interface, version "1.0" is reverted in this commit.

- Introduce directory for versioning agenda JSON schema
- Revert changes to version "1.0" since the whole point of version is compatibility and immutability
- Introduce versions "1.1" and "1.2"
- Use consistent object key names, not a mix of "spaces in keys" and "camelCasedKeys"
- Remove number data from speeches when this information is apparent from the position of items in the `speeches` array
- Format list of JSON objects in a sane way
- Move evaluator into speech object to (1) reflect a 1:1 relationship and (2) not have to use names "evaluator 1" and "evaluator 2"
- Use Title Case instead of SHOUTY UPPERCASE for speech details
- Do not encode "minutes" into a duration which is a number in minutes anyway