### PR TITLE
Improve speech picklist

### DIFF
--- a/src/pickList.js
+++ b/src/pickList.js
@@ -1616,12 +1616,34 @@ const speeches = [{
     "project": "(L5 elective) High Performance Leadership (5-7 min)"
 }];
 
-function findMatches(wordToMatch) { 
-    return speeches.filter(place => {
-        const regex = new RegExp(wordToMatch, 'gi');
-        return place.manual.match(regex) || place.project.match(regex)
-    }).slice(0, 5); // only return this many results
-} 
+// Build index of speech objects for normalized searching.
+const index = speeches.map(({manual, project}, i) => ({
+    haystack: normalize(manual + ' ' + project),
+    // Embed original index of the speech item for filtering convenience.
+    i,
+}));
+
+function normalize(string) {
+    // Extract all alphanumeric tokens and join them with spaces.
+    return string.match(/[\w\d]+/g).join(' ');
+}
+
+function findMatches(matchText) {
+    // Return nothing for blank search text to prevent matching everything.
+    if (!matchText) {
+        return [];
+    }
+    // It is okay to construct a regex in this way, since normalized match
+    // text will not contain any special characters.
+    const regex = new RegExp('\\b' + normalize(matchText), 'i');
+    return index
+        // Include only matching index items.
+        .filter(({haystack, i}) => regex.test(haystack))
+        // Get speech object for each matching index item.
+        .map(({i}) => speeches[i])
+        // Limit maximum number of results returned.
+        .slice(0, 8);
+}
 
 export default class PickList extends React.Component {
     static propTypes = {

--- a/src/speechSlot.js
+++ b/src/speechSlot.js
@@ -19,7 +19,6 @@ export default class SpeechSlot extends React.Component {
     const speechString = this.props.card.get('details');
     return <div>
       <p>{ speechString }</p>
-      <p>time: { getTime(speechString) }</p>
       <button 
           name={ speechString }
           onClick={ this.removeValue }>Cancel</button>


### PR DESCRIPTION
- Build index of speech objects with normalized text
- Normalize input query text before searching
- Prevent user input regex injection
- Do not render speech 'time' on its own, since that info is already embedded into the speech text itself

## Examples

### 1. Speeches matched regardless of dashes and punctuation

![image](https://user-images.githubusercontent.com/2456381/45646415-1a024b80-ba78-11e8-9210-3300d7084004.png)

### 2. Dashes and special characters in input query string are optional

![image](https://user-images.githubusercontent.com/2456381/45646507-66e62200-ba78-11e8-85d2-21a3860b030c.png)

### 3. Time no longer displayed on selected speech

![image](https://user-images.githubusercontent.com/2456381/45654122-378edf80-ba8f-11e8-961f-185a405b1ff1.png)

### 4. Picklist goes blank after clearing input

![image](https://user-images.githubusercontent.com/2456381/45654385-3611e700-ba90-11e8-80c9-c5171c494089.png)