### PR TITLE
Major style overhaul

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -5,7 +5,7 @@
     "disable_app_level_comments": true,
     "version_name": "2.0",
     "version_number": 7,
-    "sizing_mode": "fit_content",
+    "sizing_mode": "fill_container",
     "initial_height": 300,
     "initial_width": 300,
     "thumbnail": "icons/thumbnail.svg",

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -3,13 +3,14 @@
     "manifest_version": 4,
     "name": "Toastmasters App",
     "disable_app_level_comments": true,
-    "version_name": "1.1",
-    "version_number": 6,
+    "version_name": "2.0",
+    "version_number": 7,
     "sizing_mode": "fit_content",
     "initial_height": 300,
     "initial_width": 300,
     "thumbnail": "icons/thumbnail.svg",
     "toolbar_icon": "icons/toolbar.svg",
     "toolbar_color": "red",
+    "css_files": ["dist/app.css"],
     "js_files": ["dist/app.js"]
 }

--- a/meta/schemas/agenda-1.0.json
+++ b/meta/schemas/agenda-1.0.json
@@ -15,7 +15,7 @@
             "jokemaster": "[a quasi-funny person]",
             "toastmaster": "Max Kukartsev",
             "grammarian": "Rosaura Arevalo",
-            "ah counter": "Jack Faraday",
+            "ahCounter": "Jack Faraday",
             "timer": "Jack Faraday",
             "topicsmaster": "Anny He",
             "speeches": [
@@ -33,9 +33,9 @@
                     "duration": "5-7 minutes"
                 }
             ],
-            "general evaluator": "Ron Sison",
-            "evaluator 1": "Anny He",
-            "evaluator 2": "Max Kukartsev"
+            "generalEvaluator": "Ron Sison",
+            "evaluator1": "Anny He",
+            "evaluator2": "Max Kukartsev"
         }
     }
 }

--- a/src/pickList.css
+++ b/src/pickList.css
@@ -1,0 +1,3 @@
+.pickList li > span {
+    cursor: pointer;
+}

--- a/src/pickList.js
+++ b/src/pickList.js
@@ -1,3 +1,5 @@
+import './pickList.css';
+
 // import fs from 'fs'; // not working with webpack
 // TODO: import this from speeches.json
 const speeches = [{
@@ -1648,7 +1650,7 @@ function findMatches(matchText) {
 export default class PickList extends React.Component {
     static propTypes = {
         setSelectedSpeech: React.PropTypes.function,
-    };    
+    };
 
     constructor(props) {
         super(props);
@@ -1656,7 +1658,7 @@ export default class PickList extends React.Component {
             value: '',
             suggestions: [],
         }
-    }     
+    }
 
     componentDidMount() {
         this.setState({value : this.props.card.get('details')});
@@ -1667,43 +1669,49 @@ export default class PickList extends React.Component {
     }
 
     setSpeech = (event) => {
-        const _value = event.target.textContent.trim().toUpperCase();
+        const _value = event.target.textContent.trim();
         const speechInt = event.target.parentNode.parentNode.title;
         this.props.setSpeech(_value, speechInt);
         // hide suggestions
         this.setState({ suggestions: [] });
     }
-     
+
     displayMatches = (event) => {
         const _value = event.target.value;
         const matchArray = findMatches(_value);
-        this.setState({ 
+        this.setState({
             suggestions: matchArray,
             value: _value,
         });
     }
-     
-    render() {
-        const style = {
-            cursor: "pointer"
-        };
-        const { card } = this.props;
-        const _html = this.state.suggestions.map((_value) => {
-            return <li onClick={ this.setSpeech } style={style}>
-                <span class="hl">{_value.manual} {_value.project}</span>
-            </li>
-        });
 
-        return <div>
-            <input type="text" 
-                onChange={ this.displayMatches }
-                class="search" 
-                value={ this.state.value }
-                placeholder="Choose Manual / Speech"/>
-            <ul title={ card.get("number") } class="suggestions">
-                { _html }
-            </ul>
-        </div>
+    render() {
+        const { card } = this.props;
+        const _html = this.state.suggestions.map(_value =>
+            <li>
+                <span onClick={this.setSpeech}>
+                    {_value.manual} {_value.project}
+                </span>
+            </li>
+        );
+
+        return (
+            <div className="pickList">
+                <input
+                    type="text"
+                    onChange={this.displayMatches}
+                    class="search"
+                    value={this.state.value}
+                    placeholder="Choose Manual / Speech"
+                />
+                <ul
+                    title={card.get("number")}
+                    class="suggestions"
+                    style={{display: _html.length ? 'block' : 'none'}}
+                >
+                    {_html}
+                </ul>
+            </div>
+        );
     }
 }
-

--- a/src/pickList.js
+++ b/src/pickList.js
@@ -1670,8 +1670,7 @@ export default class PickList extends React.Component {
 
     setSpeech = (event) => {
         const _value = event.target.textContent.trim();
-        const speechInt = event.target.parentNode.parentNode.title;
-        this.props.setSpeech(_value, speechInt);
+        this.props.setSpeech(_value);
         // hide suggestions
         this.setState({ suggestions: [] });
     }
@@ -1694,6 +1693,7 @@ export default class PickList extends React.Component {
                 </span>
             </li>
         );
+        const display = _html.length ? 'block' : 'none';
 
         return (
             <div className="pickList">
@@ -1702,13 +1702,9 @@ export default class PickList extends React.Component {
                     onChange={this.displayMatches}
                     class="search"
                     value={this.state.value}
-                    placeholder="Choose Manual / Speech"
+                    placeholder="Choose speech"
                 />
-                <ul
-                    title={card.get("number")}
-                    class="suggestions"
-                    style={{display: _html.length ? 'block' : 'none'}}
-                >
+                <ul class="suggestions" style={{display}}>
                     {_html}
                 </ul>
             </div>

--- a/src/root.css
+++ b/src/root.css
@@ -1,0 +1,24 @@
+.root td {
+    padding: 0.5rem 0.5rem 0 0;
+}
+
+.root td:first-child:not([colspan]) {
+    font-weight: bold;
+    white-space: nowrap;
+    vertical-align: top;
+}
+
+/* Use :nth-child(2) instead of :last-child to exclude single <td> */
+.root td:nth-child(2) {
+    width: 100%;
+}
+
+.root .speechTitle {
+    display: flex;
+    margin: 0.25rem 0;
+}
+
+.root .speechTitle > :last-child {
+    margin-left: 0.25rem;
+    flex-grow: 1;
+}

--- a/src/root.css
+++ b/src/root.css
@@ -1,16 +1,12 @@
+/* Give all cells padding and make text stick to top */
 .root td {
     padding: 0.5rem 0.5rem 0 0;
-}
-
-.root td:first-child:not([colspan]) {
-    font-weight: bold;
-    white-space: nowrap;
     vertical-align: top;
 }
 
-/* Use :nth-child(2) instead of :last-child to exclude single <td> */
-.root td:nth-child(2) {
-    width: 100%;
+/* For all table rows but the last, make the first cell bold */
+.root tr:not(:last-child) td:first-child {
+    font-weight: bold;
 }
 
 .root .speechTitle {
@@ -18,7 +14,8 @@
     margin: 0.25rem 0;
 }
 
+/* Make rich text box take up remaining space, and give it some margin */
 .root .speechTitle > :last-child {
-    margin-left: 0.25rem;
     flex-grow: 1;
+    margin-left: 0.25rem;
 }

--- a/src/root.jsx
+++ b/src/root.jsx
@@ -1,6 +1,7 @@
 import PickList from "./pickList";
 import Speechslot from "./speechSlot";
 import { getTime } from './utils';
+import './root.css';
 
 const SPREADSHEET_ID = '1tsv0pJv6i6W8IG809Kod12x58e_7s_IfF785u4UUdpg';
 const ROLES = new Set([
@@ -37,7 +38,7 @@ class RootRecord extends quip.apps.RootRecord {
     static getProperties = () => ({
         date: quip.apps.RichTextRecord,
         toastmaster: quip.apps.RichTextRecord,
-        jokemaster: quip.apps.RichTextRecord,       
+        jokemaster: quip.apps.RichTextRecord,
         topicsmaster: quip.apps.RichTextRecord,
         generalEvaluator: quip.apps.RichTextRecord,
         speaker1: quip.apps.RichTextRecord,
@@ -48,14 +49,14 @@ class RootRecord extends quip.apps.RootRecord {
         evaluator2: quip.apps.RichTextRecord,
         grammarian: quip.apps.RichTextRecord,
         timer: quip.apps.RichTextRecord,
-        ahCounter: quip.apps.RichTextRecord,         
+        ahCounter: quip.apps.RichTextRecord,
         speakerSlot: quip.apps.RecordList.Type(SpeechSelect),
     })
 
     static getDefaultProperties = () => ({
         date: { RichText_placeholderText: "When is the meeting? Start with @Date" },
         toastmaster: { RichText_placeholderText: "Add a name" },
-        jokemaster: { RichText_placeholderText: "Add a name" }, 
+        jokemaster: { RichText_placeholderText: "Add a name" },
         topicsmaster: { RichText_placeholderText: "Add a name" },
         generalEvaluator: { RichText_placeholderText: "Add a name" },
         speaker1: { RichText_placeholderText: "Add a name" },
@@ -66,8 +67,8 @@ class RootRecord extends quip.apps.RootRecord {
         evaluator2: { RichText_placeholderText: "Add a name" },
         grammarian: { RichText_placeholderText: "Add a name" },
         timer: { RichText_placeholderText: "Add a name" },
-        ahCounter: { RichText_placeholderText: "Add a name" },    
-        speakerSlot: [],     
+        ahCounter: { RichText_placeholderText: "Add a name" },
+        speakerSlot: [],
     })
 }
 
@@ -108,15 +109,15 @@ class Root extends React.Component {
                 return Promise.reject(response);
             }
         });
-    } 
-    
+    }
+
     setSpeech = (_value, speechInt) => {
         const record = quip.apps.getRootRecord();
         const speakerSlot = record.get("speakerSlot").getRecords();
         const _card = speakerSlot.filter((card) => card.get('number') === parseInt(speechInt))[0];
-        _card.set('details', _value);        
-        
-        // Force a render without state change. 
+        _card.set('details', _value);
+
+        // Force a render without state change.
         // to show speech details
         this.forceUpdate();
     }
@@ -144,8 +145,8 @@ class Root extends React.Component {
         ];
         const record = quip.apps.getRootRecord();
         const speakerSlot = record.get("speakerSlot").getRecords();
-        const payloadObject = {}; 
-        const _speakerSlot = speakerSlot.map((card) => { 
+        const payloadObject = {};
+        const _speakerSlot = speakerSlot.map((card) => {
             const _number = card.get('number');
             const _details = card.get('details');
             const _duration = getTime(card.get('details'));
@@ -156,10 +157,10 @@ class Root extends React.Component {
                 number: _number,
                 details: _details,
                 duration: _duration,
-            }; 
+            };
         });
 
-        
+
         // TODO: get from version form manifest.json or another config file
         const obj = { version: '1.0', data: {} };
         obj.data.items = { speeches: _speakerSlot };
@@ -172,8 +173,8 @@ class Root extends React.Component {
             soa: "Jack Faraday",
             treasurer: "Ron Sison"
         };
-        
-        Object.keys(record.getData()).forEach((_key) => {     
+
+        Object.keys(record.getData()).forEach((_key) => {
             if (_key === 'speakerSlot') {
                 return;
             }
@@ -199,7 +200,7 @@ class Root extends React.Component {
             } else {
                 obj.data.items[_key] = _value;
             }
-        });        
+        });
 
         orderedPayloadKeys.forEach((str, index) => {
             orderedPayloadKeys[index] = payloadObject[str];
@@ -207,13 +208,13 @@ class Root extends React.Component {
         this.postToPath(orderedPayloadKeys);
         const url = `https://toastmasters-dev.github.io/print-agenda/?data=${encodeURIComponent(JSON.stringify(obj))}`;
         quip.apps.openLink(url);
-    } 
+    }
 
     render() {
         const record = quip.apps.getRootRecord();
         const date = record.get("date");
         const toastmaster = record.get("toastmaster");
-        const jokemaster = record.get("jokemaster"); 
+        const jokemaster = record.get("jokemaster");
         const topicsmaster = record.get('topicsmaster');
         const generalEvaluator = record.get('generalEvaluator');
         const speakerObj = {
@@ -223,44 +224,99 @@ class Root extends React.Component {
         const speechTitleObj = {
             1: record.get('speechTitle1'),
             2: record.get('speechTitle2'),
-        };         
+        };
         const evaluator1 = record.get('evaluator1');
         const evaluator2 = record.get('evaluator2');
         const grammarian = record.get('grammarian');
         const timer = record.get('timer');
         const ahCounter = record.get('ahCounter');
-        const speakerSlot = record.get("speakerSlot").getRecords();
+        const speakerSlots = record
+            .get("speakerSlot")
+            .getRecords()
+            .map(card => {
+                const _number = card.get('number');
+                return (
+                    <tr>
+                        <td>Speaker {_number}</td>
+                        <td>
+                            <quip.apps.ui.RichTextBox
+                                record={speakerObj[_number]}
+                            />
+                        <div className="speechTitle">
+                            <span>Title:</span>
+                            <quip.apps.ui.RichTextBox
+                                record={speechTitleObj[_number]}
+                            />
+                        </div>
+                        {
+                            card.get('details') ?
+                                <Speechslot
+                                    card={card}
+                                    removeValue={this.setSpeech}
+                                /> :
+                                <PickList
+                                    card={card}
+                                    setSpeech={this.setSpeech}
+                                />
+                        }
+                        </td>
+                    </tr>
+                );
+            });
 
         return (
-            <div>
-                <p>Meeting Date <quip.apps.ui.RichTextBox record={date} /></p>
-                <p>Toastmaster <quip.apps.ui.RichTextBox record={toastmaster} /></p>
-                <p>Grammarian <quip.apps.ui.RichTextBox record={grammarian} /></p>
-                <p>Timer <quip.apps.ui.RichTextBox record={timer} /></p>
-                <p>Ah Counter <quip.apps.ui.RichTextBox record={ahCounter} /></p>
-                <p>Jokemaster <quip.apps.ui.RichTextBox record={jokemaster} /></p>
-                <p>Topicsmaster <quip.apps.ui.RichTextBox record={topicsmaster} /></p>
-                {speakerSlot.map((card) => {
-                    const _number = card.get('number');
-                    return <div>
-                    <p>Speaker { _number }</p>
-                    <p>Name: <quip.apps.ui.RichTextBox record={ speakerObj[_number] } /></p>
-                    <p>Title: <quip.apps.ui.RichTextBox record={ speechTitleObj[_number] } /></p>
-                    { card.get('details') ?  
-                        <Speechslot card={ card } 
-                            removeValue={ this.setSpeech } /> :
-                        <PickList card={ card } setSpeech={ this.setSpeech } />
-                    }</div>
-                })}                 
-                <p>General Evaluator <quip.apps.ui.RichTextBox record={generalEvaluator} /></p>
-                <p>Evaluator 1 <quip.apps.ui.RichTextBox record={evaluator1} /></p>
-                <p>Evaluator 2 <quip.apps.ui.RichTextBox record={evaluator2} /></p>
-                <quip.apps.ui.Button 
-                    onClick={ this.openTab } 
-                    primary='BLUE'
-                    text='Save and Print'>
-                </quip.apps.ui.Button>
-            </div>
+            <table className="root">
+                <tr>
+                    <td>Meeting Date</td>
+                    <td><quip.apps.ui.RichTextBox record={date} /></td>
+                </tr>
+                <tr>
+                    <td>Toastmaster</td>
+                    <td><quip.apps.ui.RichTextBox record={toastmaster} /></td>
+                </tr>
+                <tr>
+                    <td>Grammarian</td>
+                    <td><quip.apps.ui.RichTextBox record={grammarian} /></td>
+                </tr>
+                <tr>
+                    <td>Timer</td>
+                    <td><quip.apps.ui.RichTextBox record={timer} /></td>
+                </tr>
+                <tr>
+                    <td>Ah Counter</td>
+                    <td><quip.apps.ui.RichTextBox record={ahCounter} /></td>
+                </tr>
+                <tr>
+                    <td>Jokemaster</td>
+                    <td><quip.apps.ui.RichTextBox record={jokemaster} /></td>
+                </tr>
+                <tr>
+                    <td>Topicsmaster</td>
+                    <td><quip.apps.ui.RichTextBox record={topicsmaster} /></td>
+                </tr>
+                {speakerSlots}
+                <tr>
+                    <td>General Evaluator</td>
+                    <td><quip.apps.ui.RichTextBox record={generalEvaluator} /></td>
+                </tr>
+                <tr>
+                    <td>Evaluator 1</td>
+                    <td><quip.apps.ui.RichTextBox record={evaluator1} /></td>
+                </tr>
+                <tr>
+                    <td>Evaluator 2</td>
+                    <td><quip.apps.ui.RichTextBox record={evaluator2} /></td>
+                </tr>
+                <tr>
+                    <td colSpan="2">
+                        <quip.apps.ui.Button
+                            onClick={this.openTab}
+                            primary='BLUE'
+                            text='Save and Print'
+                        />
+                    </td>
+                </tr>
+            </table>
         );
     }
 }

--- a/src/speechSlot.css
+++ b/src/speechSlot.css
@@ -1,0 +1,3 @@
+.speechSlot button {
+    margin-top: 0.25rem;
+}

--- a/src/speechSlot.js
+++ b/src/speechSlot.js
@@ -7,21 +7,26 @@ expect: 7
 var test3 = "4) The Press Conference (3-5 min; 2-3 min for Q&amp;A)"
 expect: 8
 */
+
 import { getTime } from './utils';
+import './speechSlot.css';
 
 export default class SpeechSlot extends React.Component {
-  removeValue = () => {
-    const speechNum = this.props.card.get('number');
-    this.props.removeValue('', speechNum);
-  }
+    removeValue = () => {
+        const speechNum = this.props.card.get('number');
+        this.props.removeValue('', speechNum);
+    }
 
-  render() {
-    const speechString = this.props.card.get('details');
-    return <div>
-      <p>{ speechString }</p>
-      <button 
-          name={ speechString }
-          onClick={ this.removeValue }>Cancel</button>
-  </div> 
-  }
+    render() {
+        const speechString = this.props.card.get('details');
+        return (
+            <div className="speechSlot">
+                <span>{ speechString }</span>
+                <br />
+                <button name={ speechString } onClick={ this.removeValue }>
+                    Cancel
+                </button>
+            </div>
+        );
+    }
 }


### PR DESCRIPTION
# More fixes

- Improve experience on small-width screens (i.e. mobile)
    - Use `"sizing_mode": "fill_container"` in manifest.json to make app responsive to narrow widths
    - Remove `width: 100%` and `white-space: nowrap` from table
- Adjust keys with spaces in agenda schema version 1.0
- Do not use attribute in `<ul title={...}>` to keep track of speech number
    - Make `PickList` completely unaware of speech number
    - Use `bind` in root.jsx to plumb speech number through to `setSpeech` callback
- Remove "number" key from speech slot record
    - Since speech slot is an ordered list record, use list item index for more efficient lookup
- Use functional style to assign data and officers values, rather than performing an imperative modification on the very next line
- Alphabetize CSS properties
- Properly pass speech project through to agenda print site

## Mobile Experience

![image](https://user-images.githubusercontent.com/2456381/46831058-27e57c80-cd57-11e8-9698-48b8d8447297.png)

# Major style overhaul

- Introduce CSS files
- Do not uppercase speech project upon selection
- Move `cursor: pointer` style in picklist from `<li>`'s to `<span>` children, to not show hand cursor when hovering over list item bullet
- Use Facebook-style `( ... )` to surround blocks of JSX
- Fix inconsistent use of spaces around property JSX properties a la `{ prop }` by favoring their removal
- Strip trailing spaces
- Remove unnecessary parentheses surrounding single argument of arrow functions: `(arg) => ...` => `arg => ...`
- Prevent display of empty `<ul>` by attaching conditional `display: none` style to it
- Become good friends with `display: flex` as a way of controlling ever-expanding-width of `<quip.apps.ui.RichTextBox>`

## Before

![image](https://user-images.githubusercontent.com/2456381/46779495-f3c57980-cccc-11e8-8e66-c077e44e1936.png)

## After

![image](https://user-images.githubusercontent.com/2456381/46779499-f9bb5a80-cccc-11e8-9ddf-49e6ca7ff5ad.png)