### PR TITLE
Even more fixes

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -4,7 +4,7 @@
     "name": "Toastmasters Agenda",
     "disable_app_level_comments": true,
     "version_name": "1.2",
-    "version_number": 8,
+    "version_number": 9,
     "sizing_mode": "fill_container",
     "initial_height": 300,
     "initial_width": 300,

--- a/src/pickList.js
+++ b/src/pickList.js
@@ -1657,7 +1657,7 @@ export default class PickList extends React.Component {
         this.state = {
             value: '',
             suggestions: [],
-        }
+        };
     }
 
     componentDidMount() {
@@ -1668,21 +1668,19 @@ export default class PickList extends React.Component {
         this.setState({value : nextProps.card.get('details')});
     }
 
-    setSpeech = (event) => {
+    setSpeech = event => {
         const _value = event.target.textContent.trim();
         this.props.setSpeech(_value);
         // hide suggestions
         this.setState({ suggestions: [] });
-    }
+    };
 
-    displayMatches = (event) => {
-        const _value = event.target.value;
-        const matchArray = findMatches(_value);
+    displayMatches = event => {
         this.setState({
-            suggestions: matchArray,
-            value: _value,
+            suggestions: findMatches(event.target.value),
+            value: event.target.value,
         });
-    }
+    };
 
     render() {
         const { card } = this.props;

--- a/src/speechSlot.js
+++ b/src/speechSlot.js
@@ -8,25 +8,13 @@ var test3 = "4) The Press Conference (3-5 min; 2-3 min for Q&amp;A)"
 expect: 8
 */
 
-import { getTime } from './utils';
+import {getTime} from './utils';
 import './speechSlot.css';
 
-export default class SpeechSlot extends React.Component {
-    removeValue = () => {
-        const speechNum = this.props.card.get('number');
-        this.props.removeValue('', speechNum);
-    }
-
-    render() {
-        const speechString = this.props.card.get('details');
-        return (
-            <div className="speechSlot">
-                <span>{ speechString }</span>
-                <br />
-                <button name={ speechString } onClick={ this.removeValue }>
-                    Cancel
-                </button>
-            </div>
-        );
-    }
-}
+export default ({card, removeValue}) => (
+    <div className="speechSlot">
+        <span>{card.get('details')}</span>
+        <br />
+        <quip.apps.ui.Button text="Cancel" onClick={removeValue} />
+    </div>
+);


### PR DESCRIPTION
- Modernize "Cancel" button style (see screenshots)
- Create helper React component `PlainRichTextBox` which restricts the styles (e.g. heading, code block) which can be used in user-edited fields
    - (Although, it is still possible to circumvent this with keyboard shortcuts or pasting content from elsewhere in the document... :unamused:)
- Use functional programming syntax where applicable
- Miscellaneous refactoring

Before
======

![image](https://user-images.githubusercontent.com/2456381/49258686-306b4280-f3eb-11e8-8121-bb111aa07bf8.png)

After
=====

![image](https://user-images.githubusercontent.com/2456381/49258690-36612380-f3eb-11e8-9c65-23e90959a6cf.png)