### PR TITLE
Change speech inclusion criteria to one non-blank field

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -4,7 +4,7 @@
     "name": "Toastmasters Agenda",
     "disable_app_level_comments": true,
     "version_name": "1.2",
-    "version_number": 10,
+    "version_number": 11,
     "sizing_mode": "fill_container",
     "initial_height": 300,
     "initial_width": 300,

--- a/src/root.jsx
+++ b/src/root.jsx
@@ -152,7 +152,7 @@ class Root extends React.Component {
                 return {project, duration, speaker, title};
             })
             // Leave only speech objects with at least one non-blank value.
-            .filter(speech => Object.values(speech).every(x => x));
+            .filter(speech => Object.values(speech).some(x => x));
 
         const archiveData = {
             date: getRichTextRecordContent(rootRecord.get('date')),


### PR DESCRIPTION
The original intent was to only exclude a speech from the printed agenda when _all_ of its fields (name, title, project/duration) are blank, but the logic committed needs only _one_ blank field. This makes it too easy to unintentionally exclude a speech by forgetting, for example, to input its title.