### PR TITLE
Let there be comments

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -4,7 +4,7 @@
     "name": "Toastmasters Agenda",
     "disable_app_level_comments": false,
     "version_name": "2.0",
-    "version_number": 14,
+    "version_number": 15,
     "sizing_mode": "fill_container",
     "initial_height": 300,
     "initial_width": 300,

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -2,7 +2,7 @@
     "id": "UDHAjApfBDr",
     "manifest_version": 4,
     "name": "Toastmasters Agenda",
-    "disable_app_level_comments": true,
+    "disable_app_level_comments": false,
     "version_name": "2.0",
     "version_number": 14,
     "sizing_mode": "fill_container",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1700,6 +1700,11 @@
                 }
             }
         },
+        "classnames": {
+            "version": "2.2.6",
+            "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+            "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+        },
         "cliui": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
     "author": "Salesforce Toastmasters",
     "devDependencies": {
         "quip-apps-webpack-config": ">=0.0.6"
+    },
+    "dependencies": {
+        "classnames": "^2.2.6"
     }
 }

--- a/src/components/comments-bubble.js
+++ b/src/components/comments-bubble.js
@@ -1,0 +1,39 @@
+import cx from 'classnames';
+import styles from 'css/roles.less';
+
+const {PropTypes} = React;
+
+export default class Role extends React.Component {
+    static propTypes = {
+        record: PropTypes.instanceOf(quip.apps.Record).isRequired,
+    };
+
+    componentDidMount() {
+        this.props.record.listenToComments(this.triggerForceUpdate);
+    }
+
+    componentWillUnmount() {
+        this.props.record.unlistenToComments(this.triggerForceUpdate);
+    }
+
+    render() {
+        const className = cx({
+            [styles.commentsBubble]: true,
+            [styles.emptyCommentsBubble]:
+                this.props.record.getCommentCount() === 0,
+        });
+
+        return (
+            <quip.apps.ui.CommentsTrigger
+                className={className}
+                record={this.props.record}
+                showEmpty={true}
+            />
+        );
+    }
+
+    /**
+     * Re-render component when there is a change in the record.
+     */
+    triggerForceUpdate = () => this.forceUpdate();
+}

--- a/src/components/role.js
+++ b/src/components/role.js
@@ -1,4 +1,5 @@
 import {RoleRecord, PlainRoleRecord, SpeechRoleRecord} from 'model/records';
+import CommentsBubble from './comments-bubble';
 import PlainRichTextBox from './plain-rich-text-box';
 import SpeechProject from './speech-project';
 import SpeechProjectSelector from './speech-project-selector';
@@ -12,26 +13,28 @@ export default class Role extends React.Component {
     };
 
     componentDidMount() {
-        this.props.roleRecord.listen(this.onRecordChange);
+        // Re-render component when there is a change on the underlying record.
+        this.props.roleRecord.listen(this.triggerForceUpdate);
     }
 
     componentWillUnmount() {
-        this.props.roleRecord.unlisten(this.onRecordChange);
+        this.props.roleRecord.unlisten(this.triggerForceUpdate);
     }
-
-    /**
-     * Re-render component when there is a change in the record.
-     *
-     * Most importantly, this tracks changes in the `speechProject` property.
-     */
-    onRecordChange = () => this.forceUpdate();
 
     render() {
         const roleName = this.props.roleRecord.get('roleName');
 
         return (
-            <tr key={roleName}>
-                <td>{roleName}</td>
+            <tr
+                key={roleName}
+                ref={node => this.props.roleRecord.setDom(node)}
+            >
+                <td>
+                    <span className={styles.roleName}>{roleName}</span>
+                </td>
+                <td>
+                    <CommentsBubble record={this.props.roleRecord} />
+                </td>
                 {this.renderContent()}
             </tr>
         );
@@ -54,8 +57,10 @@ export default class Role extends React.Component {
                 <td>
                     <PlainRichTextBox record={person} />
                     <div className={styles.speechTitle}>
-                    <span>Title:</span>
-                    <PlainRichTextBox record={roleRecord.get('speechTitle')} />
+                        <span>Title:</span>
+                        <PlainRichTextBox
+                            record={roleRecord.get('speechTitle')}
+                        />
                     </div>
                     {this.renderSpeechProject(roleRecord)}
                 </td>
@@ -79,4 +84,6 @@ export default class Role extends React.Component {
                 : <SpeechProjectSelector speechRoleRecord={roleRecord} />
         );
     }
+
+    triggerForceUpdate = () => this.forceUpdate();
 }

--- a/src/components/roles.js
+++ b/src/components/roles.js
@@ -1,4 +1,5 @@
 import {printAndSave} from 'utils/print-and-save';
+import CommentsBubble from './comments-bubble';
 import PlainRichTextBox from './plain-rich-text-box';
 import Role from './role';
 import styles from 'css/roles.less';
@@ -6,12 +7,16 @@ import styles from 'css/roles.less';
 export default function Roles() {
     const rootRecord = quip.apps.getRootRecord();
     const date = rootRecord.get('date');
+    const {ref, dateValue, commentsBubble} = getDateData(date);
 
     return (
         <table className={styles.roles}>
-            <tr>
+            <tr ref={ref}>
                 <td>Meeting Date</td>
-                <td><PlainRichTextBox record={date} /></td>
+                <td>{commentsBubble}</td>
+                <td>
+                    <PlainRichTextBox record={dateValue} />
+                </td>
             </tr>
             {
                 rootRecord
@@ -35,3 +40,16 @@ export default function Roles() {
     );
 }
 
+// TODO(#26): Drop conditional logic after data migration to `DateRecord` is
+//     complete.
+const getDateData = dateRecord => dateRecord.setDom
+    ? {
+        ref: node => dateRecord.setDom(node),
+        dateValue: dateRecord.get('value'),
+        commentsBubble: <CommentsBubble record={dateRecord} />,
+    }
+    : {
+        ref: () => {},
+        dateValue: dateRecord,
+        commentsBubble: null,
+    };

--- a/src/css/role.less
+++ b/src/css/role.less
@@ -3,8 +3,21 @@
     margin: 0.25rem 0;
 }
 
-/* Make rich text box take up remaining space, and give it some margin */
+/*
+ * Align static text with `RichTextBox` text baseline.
+ */
+.speechTitle > :first-child {
+    line-height: 21px;
+}
+
+/*
+ * Make rich text box take up remaining space, and give it some margin.
+ */
 .speechTitle > :last-child {
     flex-grow: 1;
     margin-left: 0.25rem;
+}
+
+.roleName {
+    vertical-align: top;
 }

--- a/src/css/roles.less
+++ b/src/css/roles.less
@@ -1,10 +1,46 @@
-/* Give all cells padding and make text stick to top */
+/*
+ * Give all cells padding and make text stick to top.
+ */
 .roles td {
-    padding: 0.5rem 0.5rem 0 0;
+    padding: 0.25rem;
     vertical-align: top;
 }
 
-/* For all table rows but the last, make the first cell bold */
+.roles td:first-child {
+    padding-left: 0;
+}
+
+.roles td:last-child {
+    padding-right: 0;
+}
+
+/*
+ * Omit rule `.roles tr:first-child td { padding-top: 0; }` to give first table
+ * row (i.e. meeting date) enough space between its text and the top edge of
+ * the comment section highlight.
+ */
+
+.roles tr:last-child td {
+    padding-bottom: 0;
+}
+
+/*
+ * With the exception of the last table row, make the first cell bold.
+ */
 .roles tr:not(:last-child) td:first-child {
     font-weight: bold;
+}
+
+/*
+ * Align comments bubble with role text.
+ */
+.commentsBubble {
+    margin-top: 3px;
+}
+
+/*
+ * Only show comment-less bubble if the row is being hovered.
+ */
+.roles tr:not(:hover) .emptyCommentsBubble {
+    visibility: hidden;
 }

--- a/src/model/records.js
+++ b/src/model/records.js
@@ -1,5 +1,35 @@
 const NAME_PLACEHOLDER = 'Add a name using @Person';
 
+class CommentableRecord extends quip.apps.Record {
+    node = null;
+
+    getDom() {
+        return this.node;
+    }
+
+    setDom(node) {
+        this.node = node;
+    }
+
+    supportsComments() {
+        return true;
+    }
+}
+
+export class DateRecord extends CommentableRecord {
+    static getProperties = () => ({
+        value: quip.apps.RichTextRecord,
+    });
+
+    static getDefaultProperties = () => ({
+        value: {
+            RichText_placeholderText: 'When is the meeting? Start with @Date',
+        },
+    });
+}
+
+quip.apps.registerClass(DateRecord, 'date-record');
+
 export class RolesRecord extends quip.apps.Record {
     static getProperties = () => ({
         // List of record IDs, each of which points to a record in one of the
@@ -75,12 +105,12 @@ export class RolePointerRecord extends quip.apps.Record {
 quip.apps.registerClass(RolePointerRecord, 'role-pointer-record');
 
 /**
- * Common base class for different types of role records.
+ * Abstract base class for different types of role records.
  *
- * Since it is used only as a marker and never directly instantiated, this
- * class is not registered with `quip.apps.registerClass`.
+ * Because this class will not be instantiated directly, it is not registered
+ * with `quip.apps.registerClass`.
  */
-export class RoleRecord extends quip.apps.Record {}
+export class RoleRecord extends CommentableRecord {}
 
 export class PlainRoleRecord extends RoleRecord {
     static getProperties = () => ({

--- a/src/root.jsx
+++ b/src/root.jsx
@@ -6,7 +6,7 @@ import {
     getRichTextRecordContent,
 } from 'utils/utils';
 import './root.css';
-import {RolesRecord} from 'model/records';
+import {DateRecord, RolesRecord} from 'model/records';
 import Roles from 'components/roles';
 
 const SPREADSHEET_ID = '1tsv0pJv6i6W8IG809Kod12x58e_7s_IfF785u4UUdpg';
@@ -45,7 +45,7 @@ const NAME_PROMPT = 'Add a name using @Person';
 
 class RootRecord extends quip.apps.RootRecord {
     static getProperties = () => ({
-        date: quip.apps.RichTextRecord,
+        date: DateRecord,
         roles: RolesRecord,
 
         // Old data model.
@@ -68,9 +68,7 @@ class RootRecord extends quip.apps.RootRecord {
     });
 
     static getDefaultProperties = () => ({
-        date: {
-            RichText_placeholderText: "When is the meeting? Start with @Date",
-        },
+        date: {},
         roles: {},
 
         // Old data model.
@@ -392,6 +390,19 @@ quip.apps.initialize({
                 `data version.`,
             );
         }
+
+        /*
+         * Date migration logic. Uncomment after app supports both versions
+         * of date record.
+         *
+         * if (!(rootRecord.get('date') instanceof DateRecord)) {
+         *     // Migrate date record to commentable version.
+         *     const dateValue = rootRecord.clear('date', true);
+         *     const dateRecord = rootRecord.get('date');
+         *     dateRecord.clear('value');
+         *     dateRecord.set('value', dateValue);
+         * }
+         */
 
         ReactDOM.render(
             // Based on detected data version, render new or old React


### PR DESCRIPTION
Fixes #26. There are _two_ types of comments getting enabled by this PR.

# 1. App-Level Comments

App-level comments enable broadcasts concerning the entire meeting for that day.

---

![image](https://user-images.githubusercontent.com/2456381/54413942-c4200080-46b4-11e9-8bac-4812cdf3ed67.png)

---

![image](https://user-images.githubusercontent.com/2456381/54413920-b2d6f400-46b4-11e9-93bf-5864d9125e15.png)

---

# 2. Role-Specific Comments

Additional comments pertaining to individual roles are also supported. When hovering over a role, a comment bubble appears:

---

![image](https://user-images.githubusercontent.com/2456381/54414097-38f33a80-46b5-11e9-8870-053445306d8a.png)

---

![image](https://user-images.githubusercontent.com/2456381/54414448-5ffe3c00-46b6-11e9-9285-ecc24ef8990d.png)