### PR TITLE
Make large RichTextBoxes editable again

### DIFF
--- a/src/components/plain-rich-text-box.js
+++ b/src/components/plain-rich-text-box.js
@@ -1,3 +1,5 @@
+import styles from 'css/plain-rich-text-box.less';
+
 /**
  * Wrapper component for `RichTextBox` which restricts editing styles.
  *
@@ -5,6 +7,7 @@
  */
 const PlainRichTextBox = props => (
     <quip.apps.ui.RichTextBox
+        className={styles.plainRichTextBox}
         {...props}
         allowedStyles={[quip.apps.RichTextRecord.Style.TEXT_PLAIN]}
         allowedInlineStyles={[]}

--- a/src/css/plain-rich-text-box.less
+++ b/src/css/plain-rich-text-box.less
@@ -1,0 +1,14 @@
+.plainRichTextBox {
+    /*
+     * Make `RichTextBox` editable in spite of touching right table edge.
+     *
+     * Due to HTML table sizing, the widest cell sets the width of its entire
+     * column. Thus, the widest `RichTextBox` has no space to its right, making
+     * it impossible to edit if its entire text is composed of an @-mention
+     * (which opens a new message box when clicked).
+     *
+     * This bit of CSS adds an extra space past the right edge of the table,
+     * making such `RichTextBox` instances editable.
+     */
+    width: ~"calc(100% + 2rem)";
+}


### PR DESCRIPTION
To illustrate what this change does, consider the screenshot below, which shows borders around the text boxes and the entire table:

![image](https://user-images.githubusercontent.com/2456381/54572622-d1373b00-49a5-11e9-82be-a6fa1193e601.png)

Previously, the text box for Grammarian would not be editable. But now, thanks to the extra space to its right, it is possible to click into it and edit the text.