### PR TITLE
Fix print and save

### DIFF
--- a/src/utils/print-and-save.js
+++ b/src/utils/print-and-save.js
@@ -86,7 +86,8 @@ function getPrintAgendaData() {
     return {
         version: '1.0',
         data: {
-            date: getRichTextRecordContent(rootRecord.get('date')),
+            date:
+                getRichTextRecordContent(rootRecord.get('date').get('value')),
             // TODO (#12): Use site preferences to store officer names instead
             //     of hard-coding.
             officers: {


### PR DESCRIPTION
After #28 and #32, the date format changed to become commentable. However, the `printAndSave` functionality was not updated to reflect this change... Until now.